### PR TITLE
Fix en passant

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,6 +15,7 @@ dependencies = [
 name = "chess"
 version = "0.1.0"
 dependencies = [
+ "paste",
  "regex",
 ]
 
@@ -23,6 +24,12 @@ name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+
+[[package]]
+name = "paste"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f746c4065a8fa3fe23974dd82f15431cc8d40779821001404d10d2e79ca7d79"
 
 [[package]]
 name = "regex"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,6 @@ edition = "2021"
 
 [dependencies]
 regex = "1"
+
+[dev-dependencies]
+paste = "1.0.12"


### PR DESCRIPTION
Fixes a couple of problems with the en passant implementation:

1. A `-` in the en passant field would cause an error.
2. The bitboard generated by the en passant field was backwards.

This commit also adds some unit tests and a convenience macro for testing FENs. The macro does not support testing the bitboards.